### PR TITLE
docs: Adiciona pastas e templates temporários para documentação dos núcleos

### DIFF
--- a/nucleos-temporario/ nucleo-audiovisual/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-audiovisual/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-audiovisual/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-audiovisual/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-comunicacao/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-comunicacao/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-comunicacao/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-comunicacao/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-curadoria/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-curadoria/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-curadoria/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-curadoria/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-dados-e-analises/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-dados-e-analises/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-dados-e-analises/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-dados-e-analises/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-documentacao/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-documentacao/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-documentacao/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-documentacao/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-eventos/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-eventos/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-eventos/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-eventos/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-financeiro/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-financeiro/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-financeiro/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-financeiro/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-infra/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-infra/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-infra/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-infra/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-open-source/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-open-source/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-open-source/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-open-source/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-pessoas-e-vagas/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-pessoas-e-vagas/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-pessoas-e-vagas/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-pessoas-e-vagas/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+

--- a/nucleos-temporario/ nucleo-possibilidades/docs/guia-do-nucleo-{nome}.md
+++ b/nucleos-temporario/ nucleo-possibilidades/docs/guia-do-nucleo-{nome}.md
@@ -1,0 +1,132 @@
+# 📘 Guia do Núcleo {NOME DO NÚCLEO}
+
+Boas-vindas ao documento oficial deste núcleo da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Descreva de forma simples qual é a missão e o objetivo deste núcleo dentro da comunidade.
+
+> Exemplo: "Este núcleo existe para organizar e facilitar as ações de comunicação da Cumbuca Dev, garantindo clareza, acessibilidade e alinhamento com nosso propósito."
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** {Nome} — **GitHub:** @{handle}
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- {Nome} — @{handle} — {Responsabilidade}
+
+### ✨ Pessoas Contribuidoras
+Pessoas que participam pontualmente ou em colaboração contínua, independentemente do nível técnico.
+
+- {Nome} — @{handle} — {Atividade}
+
+---
+
+## 🗂️ 3. Responsabilidades do Núcleo
+Liste as principais tarefas deste núcleo.
+
+| Tarefa | Descrição | Responsável | Status |
+|-------|-----------|-------------|--------|
+| {Tarefa} | {Descrição} | @{handle} | ativa / pausada |
+| ... | ... | ... | ... |
+
+---
+
+## 🔄 4. Como o Núcleo Funciona
+
+### 📅 Reuniões
+<!-- Ajustar conforme combinado, interessante mencionar o assync -->
+- Periodicidade: {ex.: semanal, quinzenal}
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente:
+
+### 🧭 Fluxo de Trabalho
+<!-- Aqui pode também ajustar conforme fizer sentido para o núcleo -->
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**  
+   Agora você terá uma cópia no seu GitHub.
+
+Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com:  
+     *Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+- Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+- Origem: sua branch no seu fork  
+- Destino: `main` do repositório oficial  
+- Sempre incluir na descrição:
+  - resumo do que foi feito
+  - checklist do que está completo ou em andamento
+  - closes #link da issue
+
+6. **Aguarde revisões**  
+- Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+- Ajustes podem ser solicitados  
+- Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+- A pessoa responsável pelo PR faz o merge!
+
+
+## 💬 5. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+Guia oficial:  
+https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 6. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 7. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 8. Histórico
+- Última atualização: {data}
+- Atualizado por: @{handle}

--- a/nucleos-temporario/ nucleo-possibilidades/reunioes/DD-MM-YY.md
+++ b/nucleos-temporario/ nucleo-possibilidades/reunioes/DD-MM-YY.md
@@ -1,0 +1,54 @@
+# 📝 Reunião — {DATA}
+
+## 👥 Pessoas Presentes
+- @{handle}
+- @{handle}
+
+---
+
+## 📋 Pauta
+- {tópico 1}
+- {tópico 2}
+- {tópico 3}
+
+---
+
+## 🧠 Discussões
+- {Resumo do que foi debatido}
+- {Resumo do que foi debatido}
+
+---
+
+## ✅ Decisões
+- {Decisão importante tomada}
+- {Decisão importante tomada}
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| {ação} | @{handle} | {data} |
+| {ação} | @{handle} | {data} |
+
+---
+
+## 🔄 Pendências
+- {pendência}
+- {pendência}
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): {link}
+- PR(s): {link}
+- Materiais: {link}
+- Gravação do Encontro: {link}
+
+---
+
+## 🗒 Observações
+{informações adicionais que não se encaixam nas seções acima}
+
+


### PR DESCRIPTION
Como ainda não temos um padrão de arquitetura, mas já estamos iniciando a organizar os núcleos, criei estes arquivos e templates temporários para darmos os primeiros passos dentro deste repo. 

- [x] Adição da pasta `nucleo-temporario`
- [x] Subpastas contendo os 11 núcleos
- [x] Dentro de cada pasta, 2 pastas: pasta **docs** - destinadas à documentação do núcleo, dentro dela um arquivo de template `guia-do-nucleo-{nome}.md` ; pasta **reunioes**, dentro dela um arquivo de template `DD-MM-YY`, para documentação das atas.

Para o fluxo de trabalho, coloquei nos templates o fluxo com uso de fork, mesmo que tenhamos permissões. Não sei se faz sentido, pessoas mantenedoras do repo, fiquem à vontade para fazer/sugerir alterações :)

closes #6 