### PR TITLE
docs: Update Guia do Núcleo Eventos and add two meeting minutes

### DIFF
--- a/docs-temp/nucleos/nucleo-eventos/docs/guia-do-nucleo-eventos.md
+++ b/docs-temp/nucleos/nucleo-eventos/docs/guia-do-nucleo-eventos.md
@@ -1,0 +1,115 @@
+# 📘 Guia do Núcleo de Eventos
+
+Boas-vindas ao documento oficial do Núcleo de Eventos da Cumbuca Dev!  
+Aqui você encontra tudo o que precisa para entender como o núcleo funciona, quem participa e como colaborar.
+
+---
+
+## 🌱 1. Propósito do Núcleo
+Organizar, planejar e executar os diversos eventos promovidos pela Cumbuca, garantindo inclusão, acessibilidade e o compartilhamento de conhecimentos.
+
+---
+
+## 👥 2. Pessoas do Núcleo
+
+### Liderança do Núcleo
+Pessoa(s) responsável(is) por facilitar processos, orientar prioridades e revisar atividades.
+
+- **Nome:** Clarice Regina — **GitHub:** [@clariceregina](https://github.com/clariceregina/)
+
+### Pessoas Mantenedoras
+Pessoas com atividade recorrente e responsabilidades específicas no núcleo.
+
+- **Nome:** Letícia Silva — **GitHub:** [@leticiadasilva](https://github.com/leticiadasilva) — **Responsabilidade**: Suporte a eventos
+- **Nome:** Maria Maia — **GitHub:** [@antoniamaia](https://github.com/antoniamaia) — **Responsabilidade**: Suporte a eventos
+- **Nome:** Rafaela Galembeck — **LinkedIn:** [/in/rafaelagalembeck/](https://www.linkedin.com/in/rafaelagalembeck/) — **Responsabilidade**: Suporte a eventos
+
+---
+
+## 🔄 3. Como o Núcleo Funciona
+
+### 📅 Reuniões
+- Periodicidade: semanal
+- Plataforma: Google Meet  
+- Registro oficial: pasta `/reunioes`
+- Link recorrente: meet.google.com/cat-rxgm-ehx
+- Comunicação assíncrona: núcleo-eventos no Slack
+
+### 🧭 Fluxo de Trabalho
+Para evitar conflitos e manter a `main` protegida, seguimos este fluxo no repositório:
+
+1. **Faça um fork do repositório oficial**  
+   - Acesse o repositório comunidade da Cumbuca Dev  
+   - Clique em **Fork**
+   - Agora você terá uma cópia no seu GitHub.
+
+   Guia de Forks (para pessoas iniciantes): 
+https://cumbucadev.gitbook.io/github-essentials/dia-11/forks-e-pull-requests/criando-um-fork-no-github
+
+2. **Escolha uma tarefa nas Issues**  
+   - Vá em *Issues*  
+   - Filtre pela label do seu núcleo  
+   - Escolha uma tarefa  
+   - Comente algo parecido com: *"Posso trabalhar nesta issue?”*
+
+3. **Crie uma branch no seu fork**  
+   Nome padrão sugerido: Número de identificação da Issue
+
+   Guia de Issues (para pessoas iniciantes):  
+https://cumbucadev.gitbook.io/github-essentials/dia-8
+
+4. **Faça as alterações no seu fork**  
+   - Organize commits pequenos e bem descritos  
+
+5. **Abra um Pull Request para o repositório oficial**  
+   - Origem: sua branch no seu fork  
+   - Destino: `main` do repositório oficial  
+   - Sempre incluir na descrição:
+     - resumo do que foi feito
+     - checklist do que está completo ou em andamento
+     - closes #link da issue
+
+6. **Aguarde revisões**  
+   - Pelo menos **1 pessoa mantenedora** do núcleo precisa revisar  
+   - Ajustes podem ser solicitados  
+   - Tudo com calma e paciência, ninguém aqui corre 💜
+
+7. **Merge aprovado**  
+   - A pessoa responsável pelo PR faz o merge!
+
+---
+
+## 💬 4. Comunicação
+<!-- Ajustar conforme fazemos no núcleo, lembrar que o Slack não tem histórico -->
+Usamos GitHub Discussions para conversas estruturadas.
+
+### Categorias:
+- 📣 **Anúncios** — uso exclusivo da liderança  
+- 💬 **Geral** — conversas abertas  
+- 💡 **Ideias** — sugestões e melhorias  
+- 🙌 **Mostrar e compartilhar** — projetos, aprendizados  
+- ❓ **Perguntas e Respostas** — dúvidas  
+- 🗳️ **Votações** — decisões coletivas  
+
+   Guia oficial: https://docs.github.com/pt/discussions
+
+---
+
+## 🧑‍🤝‍🧑 5. Como Contribuir
+1. Escolha uma issue com a label do núcleo  
+2. Comente que vai trabalhar  
+3. Siga o fluxo do núcleo  
+4. Peça ajuda quando precisar, ninguém caminha só 💜
+
+---
+
+## 🗃️ 6. Registro de Reuniões
+Todos os encontros ficam na pasta `/reunioes` usando o template:
+
+`DD-MM-YY.md`
+
+---
+
+## 🕒 7. Histórico
+- Última atualização: 20/01/2026
+- Atualizado por: [@clariceregina](https://github.com/clariceregina/)

--- a/docs-temp/nucleos/nucleo-eventos/reunioes/2026-01-13.md
+++ b/docs-temp/nucleos/nucleo-eventos/reunioes/2026-01-13.md
@@ -1,0 +1,60 @@
+# 📝 Reunião — 13/01/2026
+
+## 👥 Pessoas Presentes
+- [@antoniamaia](https://github.com/antoniamaia)
+- [@clariceregina](https://github.com/clariceregina/)
+
+---
+
+## 📋 Pauta
+- Eventos nacionais
+- Eventos internacionais
+- Planejamento dos eventos por mês
+
+---
+
+## 🧠 Discussões
+- Maria Maia inscreveu 3 palestras para Camila Maia na PyCon Alemanha 2026.
+- Perdemos o tempo de submissão para a PyCon USA 2026, mas vai tentar stand da comunidade / travel grants.
+- Em Janeiro: iniciamos o Drop Semanal de Dados, escrito pelo [@rafaelcalixto](https://github.com/rafaelcalixto).
+- Em Fevereiro: Maria Maia estará ausente de 12/02 a 24/02/2026 e em 26/02/2026 fará encontrinho da comunidade Python na Bahia.
+- Em Março: provável início das mentorias sociais da Cumbuca.
+- Em Maio: ocorrerá evento Conferência Open Source Brasil, voltado para pessoas mantenedoras. Será online e planejamos fazer em um formato open source para que outras organizações do Brasil possam fazer também.
+
+---
+
+## ✅ Decisões
+- Definimos que a frequência das reuniões será semanal. 
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| Verificar resposta PyCon | [@antoniamaia](https://github.com/antoniamaia) | 11/02/2026 |
+| Criar issue para Clarice Regina organizar o repositório e atas | [@antoniamaia](https://github.com/antoniamaia) | 20/02/2026 |
+| Organizar o repositório e atas | [@clariceregina](https://github.com/clariceregina/) | 27/02/2026
+
+---
+
+## 🔄 Pendências
+- Mentorias sociais dependem da Camila Maia finalizar o material da mentoria.
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): https://github.com/cumbucadev/comunidade/issues/8
+- PR(s): --
+- Materiais:
+    - Travel Grants PyCon USA: https://us.pycon.org/2026/attend/travel-grants/
+    - Community Booths PyCon USA: https://us.pycon.org/2026/attend/community-booths/
+    - PyCon Alemanha: https://2026.pycon.de/
+- Gravação do Encontro: https://drive.google.com/file/d/1K1Q_6vkO9DhmKLyZ81YAUsKlGRiMHT1W/view?usp=sharing
+
+---
+
+## 🗒 Observações
+--
+
+

--- a/docs-temp/nucleos/nucleo-eventos/reunioes/2026-01-20.md
+++ b/docs-temp/nucleos/nucleo-eventos/reunioes/2026-01-20.md
@@ -1,0 +1,64 @@
+# 📝 Reunião — 20/01/2026
+
+## 👥 Pessoas Presentes
+- [@antoniamaia](https://github.com/antoniamaia)
+- [@clariceregina](https://github.com/clariceregina/)
+- [@rafaelagalembeck]([/in/rafaelagalembeck/](https://www.linkedin.com/in/rafaelagalembeck/))
+
+---
+
+## 📋 Pauta
+- Apresentação da [pasta do núcleo no GitHub](https://github.com/cumbucadev/comunidade/tree/main/docs-temp/nucleos/nucleo-eventos)
+- Temas transversais para eventos
+- Datas de diversidade e inclusão
+- Evento Conferência Open Source Brasil
+
+---
+
+## 🧠 Discussões
+- Rafaela Galembeck sugeriu eventos com temáticas relacionadas a diversidade, inclusão e saúde mental, como:
+    - Abril: autismo
+    - Junho: pessoas LGBT+
+    - Setembro: pessoas com deficiência
+    - Setembro: conscientização contra suicídio
+    - Novembro: consciência negra
+- Maria Maia sugeriu que seria interessante apoio psicológico às pessoas mentoradas durante a mentoria social da Cumbuca. Rafaela Galembeck disse conhecer profissionais que realizam atendimento a preço social e que poderia surgir alguma parceria. 
+- Maria Maia comentou que Jojo havia sugerido a criação de um repositório com informações de contribuições para a comunidade e currículo das pessoas envolvidas com a Cumbuca. 
+- Maria vai começar a planejar evento de maio (mês da pessoa mantenedora), porque vê muitas possibilidades de patrocínio e é necessário começar a se movimentar com antecedência para fazer os contatos necessários.
+- O objetivo da Conferência Open Source Brasil é o contato inicial com empresas que não conhecem nosso trabalho, assim como contato com a comunidade e outros projetos open source brasileiros.
+
+---
+
+## ✅ Decisões
+- Provável data para o eventos Conferência Open Source Brasil será 30 e 31/05/2026
+
+---
+
+## 🚀 Próximos Passos
+
+| Ação | Responsável | Prazo |
+|------|-------------|-------|
+| Verificar resposta PyCon | [@antoniamaia](https://github.com/antoniamaia) | 11/02/2026 |
+| Criar issue para Maria Maia organizar o esqueleto do evento Open Source Brasil | [@clariceregina](https://github.com/clariceregina/) | 27/02/2026 |
+| Organizar o repositório e atas | [@clariceregina](https://github.com/clariceregina/) | 27/02/2026
+
+---
+
+## 🔄 Pendências
+--
+
+---
+
+## 🔗 Links Importantes
+- Issue(s) relacionada(s): https://github.com/cumbucadev/comunidade/issues/8
+- PR(s): --
+- Materiais:
+    - Pasta do núcleo de eventos no GitHub: https://github.com/cumbucadev/comunidade/tree/main/docs-temp/nucleos/nucleo-eventos
+- Gravação do Encontro: --
+
+---
+
+## 🗒 Observações
+--
+
+


### PR DESCRIPTION
Resumo: Atualizei o Guia do Núcleo de Eventos com as informações do núcleo; Adicionei as atas das reuniões do Núcleo de Eventos dos dias 13 e 20/01/2026.

Summary: I updated the Núcleo de Eventos Guide with the core information and added the meeting minutes for the Núcleo de Eventos meetings on January 13 and 20, 2026.

closes #8 