### PR TITLE
docs: emails institucionais

### DIFF
--- a/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/README.md
+++ b/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/README.md
@@ -1,0 +1,37 @@
+# Emails Institucionais | Cumbuca Dev
+
+Esta seção reúne a documentação relacionada aos emails institucionais da Cumbuca Dev.
+
+Os documentos aqui presentes descrevem tanto o uso cotidiano das contas quanto os procedimentos de
+gerenciamento e a visão geral da infraestrutura.
+
+## Estrutura
+
+* **[Guia de Uso](guia-de-uso.md)**
+  Orientações para utilização dos emails institucionais, incluindo acesso, envio de mensagens e boas práticas.
+
+* **[Guia de Gerenciamento](guia-de-gerenciamento.md)**
+  Procedimentos para administração das contas, como criação de emails, encaminhamentos e configurações operacionais.
+
+* **[Infraestrutura de Emails](infraestrutura.md)**
+  Visão geral da arquitetura do sistema de emails da Cumbuca Dev, explicando os componentes envolvidos e como eles se conectam.
+
+## Objetivo
+
+Esta documentação tem como propósito:
+
+* Padronizar o uso dos emails institucionais
+* Facilitar o gerenciamento das contas
+* Garantir continuidade organizacional
+* Oferecer transparência sobre a infraestrutura
+
+## Suporte e alterações
+
+Sempre que necessário:
+
+* Solicitações de criação ou ajustes
+* Problemas de envio ou recebimento
+* Dúvidas sobre acesso ou configuração
+
+Devem ser registradas por meio de issue direcionada ao **Núcleo Infra**:
+<https://github.com/cumbucadev/comunidade/issues>.

--- a/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/guia-de-gerenciamento.md
+++ b/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/guia-de-gerenciamento.md
@@ -1,0 +1,180 @@
+# Guia de Gerenciamento dos Emails Institucionais
+
+Este guia apresenta os procedimentos para gerenciamento dos emails institucionais da Cumbuca Dev.
+
+As orientações descritas aqui destinam-se às pessoas responsáveis pela administração das contas, incluindo criação, manutenção e ajustes de acesso.
+
+## Acesso ao painel de gerenciamento
+
+O gerenciamento das contas é realizado através do ISPConfig.
+
+O acesso ao painel administrativo pode ser feito utilizando as credenciais disponíveis no 1Password, armazenadas no cofre Engenharia sob o nome `web admin panel`.
+
+Acesse o painel em <https://isp.umbahost.com.br:8080>.
+
+Após a autenticação, todas as operações relacionadas aos emails institucionais poderão ser realizadas pela interface.
+
+## Criação de um novo email institucional
+
+A criação de uma nova conta deve seguir o padrão institucional adotado pela comunidade.
+
+No painel:
+
+> Email → Contas de email → Adicionar novo email
+
+Preencha os campos principais:
+
+* **Nome**
+Identificação descritiva da conta
+Exemplo: Eventos, Documentação
+
+* **Email**
+Nome do endereço
+Exemplo: eventos, documentacao
+
+* **Senha**
+Utilizar o 1Password para gerar a senha e armazenar as credenciais no cofre Engenharia seguindo o padrão:
+
+`webmail <email>@`
+
+Exemplos:
+
+`webmail eventos@`
+`webmail documentacao@`
+
+* **Repetir Senha**
+Repetir a senha gerada
+
+Os demais campos podem permanecer com as configurações padrão.
+
+Após salvar, a conta passa a existir imediatamente.
+
+## Edição de um email existente
+
+Alterações em contas já criadas são realizadas diretamente na mailbox.
+
+No painel:
+
+> Email → Contas de email → Selecionar conta → Editar
+
+Entre os ajustes mais comuns estão:
+
+* Redefinição de senha
+* Alteração de quota
+* Ativação ou desativação de serviços
+* Configuração de encaminhamento
+
+## Configuração de encaminhamento (forward)
+
+O encaminhamento permite que mensagens enviadas para um email institucional sejam automaticamente redirecionadas para outros endereços.
+
+Esse é o modelo padrão de acesso adotado pela Cumbuca Dev, pois possibilita que múltiplos responsáveis recebam mensagens sem a necessidade de compartilhamento de credenciais.
+
+O email institucional permanece ativo normalmente, enquanto as mensagens também são entregues aos destinatários configurados.
+
+### Como configurar
+
+No painel:
+
+> Email → Contas de email → Selecionar conta → Editar
+
+Ao editar a conta, localize o campo:
+
+**Enviar cópia para**
+
+Adicione os endereços de destino, separando múltiplos destinatários com vírgulas.
+
+### Exemplo
+
+Ao editar a conta comunicacao@cumbuca.dev:
+
+* **Enviar cópia para**
+`responsavel1@gmail.com, responsavel2@gmail.com`
+
+### Comportamento esperado
+
+Após salvar:
+
+• Novas mensagens passam a ser encaminhadas automaticamente
+• O email institucional permanece ativo
+• Não há impacto no endereço original
+
+As alterações entram em vigor imediatamente.
+
+## Boas práticas de gerenciamento
+
+Durante a administração das contas:
+
+* Manter nomenclatura padronizada
+* Armazenar credenciais no 1Password
+* Evitar compartilhamento manual de senhas
+* Priorizar encaminhamentos em vez de múltiplos logins
+* Registrar decisões relevantes quando aplicável
+
+## Configuração de envio via Gmail
+
+O Gmail pode ser utilizado como interface de envio institucional.
+
+Essa configuração permite enviar mensagens pelo Gmail utilizando o endereço institucional como remetente.
+
+No Gmail:
+
+> Configurações → Ver todas as configurações
+
+> Aba → Contas e Importação
+
+> Seção → Enviar e-mail como → Adicionar outro endereço de e-mail
+
+Informe:
+
+* **Nome**
+Identificação desejada
+Exemplo: Eventos Cumbuca Dev
+
+* **Endereço**
+Email institucional
+Exemplo: eventos@cumbuca.dev
+
+Em seguida:
+
+* Desmarcar a opção `Tratar como um alias`
+* Clicar em **Próxima Etapa**
+
+## Configuração SMTP
+
+Utilize as credenciais disponíveis no 1Password.
+
+Padrão:
+
+`webmail <email>@`
+
+Preencha:
+
+* **Nome de usuário**
+Email institucional completo
+
+* **Senha**
+Senha da mailbox
+
+Manter:
+
+Servidor SMTP → `isp.umbahost.com.br`
+Porta → `587`
+Segurança → `TLS`
+
+Não alterar os demais campos.
+
+Após salvar, o Gmail enviará um email de verificação.
+
+Uma vez confirmado, o endereço institucional ficará disponível como opção no campo **“De:”**.
+
+## Alterações e suporte
+
+Situações que envolvam:
+
+* Criação de novas contas
+* Ajustes estruturais
+* Mudanças de acesso
+* Problemas de envio ou recebimento
+
+Devem ser registradas por meio de issue direcionada ao **Núcleo Infra** em <https://github.com/cumbucadev/comunidade/issues>.

--- a/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/guia-de-uso.md
+++ b/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/guia-de-uso.md
@@ -1,0 +1,128 @@
+# Guia de Uso dos Emails Institucionais
+
+Este guia reúne orientações para utilização dos emails institucionais da Cumbuca Dev.
+
+Os emails institucionais fazem parte da comunicação oficial da comunidade, permitindo a representação dos núcleos, o contato com parceiros e o registro de interações organizacionais.
+
+## O que é um email institucional
+
+Um email institucional é um endereço vinculado à organização, criado para representar núcleos, funções ou áreas específicas.
+
+Exemplos:
+
+* [contato@cumbuca.dev](mailto:contato@cumbuca.dev)
+* [infra@cumbuca.dev](mailto:infra@cumbuca.dev)
+* [opensource@cumbuca.dev](mailto:opensource@cumbuca.dev)
+* [pessoas-e-vagas@cumbuca.dev](mailto:pessoas-e-vagas@cumbuca.dev)
+
+Esses endereços pertencem à estrutura organizacional da comunidade e permanecem os mesmos mesmo quando há transição de responsáveis.
+
+## Funcionamento dos emails da Cumbuca Dev
+
+Os emails institucionais seguem um modelo padronizado:
+
+* As contas existem no servidor da Cumbuca Dev
+* As mensagens podem ser acessadas via webmail
+* Pode haver encaminhamento automático para Gmail ou outros destinos
+
+Esse modelo garante flexibilidade de acesso e continuidade organizacional.
+
+## Acesso via Webmail
+
+O webmail é a interface padrão de acesso aos emails.
+
+Acesse em: [https://webmail.cumbuca.dev](https://webmail.cumbuca.dev)
+
+Para se logar, utilize as credenciais (email e senha) disponíveis no cofre Engenharia do 1Password.
+Procure pelo padrão `webmail ...`.
+
+Exemplos:
+
+* `webmail contato@`
+* `webmail infra@`
+* `webmail documentacao@`
+
+O webmail permite leitura, envio e gerenciamento de mensagens, de forma semelhante a outros clientes de email como Gmail ou Outlook.
+
+## Recebimento automático (encaminhamento)
+
+Alguns emails institucionais utilizam encaminhamento automático.
+
+Nesse cenário:
+
+* Mensagens enviadas ao email institucional são redirecionadas para os responsáveis
+* O acompanhamento ocorre diretamente no Gmail ou destino configurado
+
+O encaminhamento não altera o endereço institucional, apenas a forma de acesso às mensagens.
+
+Caso seja necessário criar, remover ou ajustar encaminhamentos, abra uma issue direcionada ao **Núcleo Infra** em [Issues da Comunidade][issues-comunidade].
+
+## Envio de mensagens
+
+As mensagens podem ser enviadas de duas formas.
+
+### Via Webmail
+
+Através do acesso em: [https://webmail.cumbuca.dev](https://webmail.cumbuca.dev).
+
+### Via Gmail
+
+Quando configurado, o Gmail pode ser utilizado como interface de envio. Nesse modelo:
+
+* O envio é realizado pelo servidor da Cumbuca Dev
+* O destinatário visualiza o email institucional como remetente
+
+Após a configuração, o endereço institucional passa a ficar disponível como opção de remetente dentro do Gmail. Ao escrever um novo email, você poderá escolher qual endereço deseja utilizar.
+
+Exemplo:
+
+No campo **“De:”**, será possível alternar entre:
+
+[seuemail@gmail.com](mailto:seuemail@gmail.com)
+[infra@cumbuca.dev](mailto:infra@cumbuca.dev)
+[comunicacao@cumbuca.dev](mailto:comunicacao@cumbuca.dev)
+
+Isso permite utilizar o Gmail normalmente, mantendo o envio institucional quando necessário.
+
+Caso essa funcionalidade não esteja disponível, abra uma issue direcionada ao **Núcleo Infra** em [Issues da Comunidade][issues-comunidade].
+
+## Uso dos emails institucionais
+
+Os emails institucionais são utilizados para:
+
+* Comunicação oficial dos núcleos
+* Interações institucionais
+* Contato com parceiros e comunidade
+* Registros organizacionais
+
+O uso deve estar alinhado às atividades da função ou núcleo representado.
+
+## Boas práticas
+
+Para manter a organização e a continuidade:
+
+* Utilizar linguagem apropriada ao contexto institucional
+* Evitar uso pessoal do endereço
+* Manter organização das mensagens quando houver acesso direto
+* Reportar dúvidas ou problemas por meio de issue direcionada ao **Núcleo Infra**
+
+## Segurança e acesso
+
+Quando houver acesso direto à conta:
+
+* As credenciais devem ser mantidas em segurança
+* Senhas não devem ser compartilhadas manualmente. Utilize exclusivamente o 1Password para gerenciamento e concessão de acesso
+* Alterações de acesso devem ser solicitadas por meio de issue
+
+## Suporte
+
+O **Núcleo Infra** pode auxiliar em situações como:
+
+* Falhas de recebimento
+* Problemas de envio
+* Reset de senha
+* Ajustes de encaminhamento
+
+Para isso, abra uma issue direcionada ao núcleo em [Issues da Comunidade][issues-comunidade].
+
+[issues-comunidade]: https://github.com/cumbucadev/comunidade/issues

--- a/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/infraestrutura.md
+++ b/docs-temp/nucleos/nucleo-infra/docs/emails-institucionais/infraestrutura.md
@@ -1,0 +1,133 @@
+# Como funciona o sistema de emails da Cumbuca Dev
+
+Este documento explica, de forma simples, como funciona a infraestrutura de emails da Cumbuca Dev.
+A proposta é ajudar qualquer pessoa da comunidade a compreender o funcionamento básico do sistema e
+como seus componentes se conectam.
+
+## Visão geral
+
+Quando alguém envia um email para um endereço como `contato@cumbuca.dev`, existe um conjunto de tecnologias operando nos bastidores para garantir que essa mensagem seja entregue corretamente.
+
+De forma simplificada, o processo ocorre da seguinte maneira:
+
+* O domínio identifica a organização
+* O DNS direciona a mensagem
+* O servidor recebe o email
+* A mensagem é armazenada
+* Usuários acessam o conteúdo
+
+## O domínio
+
+O domínio `cumbuca.dev` é o que permite que a comunidade possua emails próprios. Ele funciona como o
+endereço oficial da organização na internet e é um elemento essencial para a existência dos emails
+institucionais.
+
+O domínio foi adquirido via [WordPress.com](https://wordpress.com/) e sua renovação é realizada
+anualmente por meio da plataforma.
+
+_Caso seja necessário acessar o WordPress.com e não possua permissão, uma issue direcionada ao_
+_Núcleo Infra deve ser aberta em: <https://github.com/cumbucadev/comunidade/issues>._
+
+## O DNS (o direcionador do sistema)
+
+O DNS pode ser entendido como um sistema de localização da internet. Ele informa para onde cada
+serviço do domínio deve apontar. No caso dos emails, o DNS contém uma configuração essencial:
+**o registro MX**.
+
+### O que é o registro MX
+
+O registro MX é a configuração responsável por definir para qual servidor os emails do domínio devem
+ser enviados.
+
+Quando alguém envia um email para a Cumbuca Dev:
+
+1. O servidor de origem consulta o DNS
+2. O DNS informa qual servidor recebe emails
+3. A mensagem é entregue
+
+Sem o registro MX, os emails não poderiam ser recebidos.
+
+### Onde isso é configurado
+
+As configurações de DNS da Cumbuca Dev são gerenciadas no
+[Cloudflare](https://www.cloudflare.com/).
+
+Dentro do Cloudflare, em `DNS → Records`, é possível visualizar e administrar os registros do
+domínio, incluindo aqueles do tipo MX.
+
+_Caso seja necessário acessar o Cloudflare e não possua permissão, uma issue direcionada ao_
+_Núcleo Infra deve ser aberta em: <https://github.com/cumbucadev/comunidade/issues>._
+
+## O servidor de email
+
+O servidor de email é o sistema responsável por processar as mensagens. Ele executa duas funções
+principais:
+
+* Receber e enviar emails
+* Armazenar mensagens
+
+Na infraestrutura da Cumbuca Dev, o servidor é mantido pela provedora de hospedagem utilizada pela
+comunidade.
+
+## O webmail
+
+Na Cumbuca Dev utilizamos o [Roundcube](https://roundcube.net/) como webmail, a interface que permite acessar emails diretamente pelo navegador.
+
+Acesso o webmail da Cumbuca Dev em: <https://webmail.cumbuca.dev>
+
+O webmail funciona de maneira semelhante ao Gmail ou Outlook, oferecendo recursos de leitura, envio
+e organização de mensagens.
+
+O Roundcube não armazena mensagens. Ele apenas exibe o conteúdo presente no servidor.
+
+## O painel de gerenciamento
+
+O gerenciamento das contas é realizado através do
+[ISPConfig](https://www.ispconfig.org/), o painel administrativo utilizado para administrar a
+infraestrutura de emails.
+
+O painel permite:
+
+* Criar emails
+* Ajustar encaminhamentos
+* Gerenciar configurações
+
+O ISPConfig não transporta mensagens. Ele apenas administra o sistema e escreve configurações para o
+servidor.
+
+O endereço do painel administrativo da Cumbuca Dev é: <https://isp.umbahost.com.br:8080>
+
+_Caso seja necessário acessar o painel e não possua permissão, uma issue direcionada ao_
+_Núcleo Infra deve ser aberta em: <https://github.com/cumbucadev/comunidade/issues>._
+
+## Como os emails chegam até você
+
+Quando alguém envia um email para a Cumbuca Dev:
+
+1. O DNS informa o servidor correto
+2. O servidor recebe a mensagem
+3. A mensagem é armazenada na caixa de entrada
+4. O webmail ou Gmail exibem o conteúdo
+
+## Encaminhamento (forward)
+
+A Cumbuca Dev utiliza encaminhamento automático em diversas contas. Isso significa que:
+
+* O email institucional permanece ativo
+* As mensagens são redirecionadas para os responsáveis
+
+Esse modelo evita o compartilhamento de credenciais e facilita transições de responsabilidade.
+
+## Conclusão
+
+O sistema de emails da Cumbuca Dev é formado por diferentes componentes que operam em conjunto.
+
+* WordPress.com → registro e propriedade do domínio
+* Domínio (cumbuca.dev) → identidade institucional
+* Cloudflare → direcionamento e resolução DNS
+* Servidor de email → transporte, armazenamento e acesso
+* Roundcube → interface de webmail
+* ISPConfig → gerenciamento da infraestrutura
+
+Essa estrutura garante que a comunidade disponha de emails institucionais estáveis, organizados e
+sustentáveis.


### PR DESCRIPTION
## Contexto

Com a adoção dos emails institucionais da Cumbuca Dev, tornou-se necessário organizar e centralizar a documentação relacionada ao uso, gerenciamento e infraestrutura do sistema de emails.

Até então, essas informações encontravam-se dispersas ou implícitas.

## O que este PR faz

Este PR adiciona a estrutura inicial de documentação dos emails institucionais, incluindo:

* Guia de uso das contas institucionais
* Guia de gerenciamento das contas
* Documento explicando a infraestrutura de emails
* README centralizando e referenciando os materiais

## Objetivo

* Padronizar orientações para a comunidade
* Reduzir dúvidas operacionais
* Facilitar onboarding de novas pessoas responsáveis
* Oferecer transparência sobre a arquitetura adotada

## Impacto

Não há alterações técnicas na infraestrutura. Este PR introduz exclusivamente documentação.

Closes #10 