### PR TITLE
fix: Workflow de preview de documentação falha em PRs de fork

### DIFF
--- a/.github/workflows/comment-preview-documentation.yml
+++ b/.github/workflows/comment-preview-documentation.yml
@@ -8,6 +8,8 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
+  actions: read
 
 jobs:
   comment:

--- a/.github/workflows/comment-preview-documentation.yml
+++ b/.github/workflows/comment-preview-documentation.yml
@@ -1,0 +1,88 @@
+name: Comment Preview Documentation
+
+on:
+  workflow_run:
+    workflows: ["Deploy Preview Documentation"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR metadata artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR with preview link
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = parseInt(require('fs').readFileSync('pr_number.txt', 'utf8').trim());
+            const isFork =
+              context.payload.workflow_run.head_repository.full_name !== `${owner}/${repo}`;
+            const runId = context.payload.workflow_run.id;
+
+            const previewUrl = `https://docs.cumbuca.dev/preview/pr/${prNumber}/`;
+
+            const body = isFork
+              ? `## 📖 Pré-visualização da Documentação
+
+            ✅ A documentação foi compilada com sucesso!
+
+            ### 📦 Baixar pré-visualização:
+            Como este PR vem de um fork, o deploy automático não é possível por restrições de segurança do GitHub Actions.
+
+            **[⬇️ Acessar artifact da documentação](https://github.com/${owner}/${repo}/actions/runs/${runId})**
+
+            1. Acesse o link acima
+            2. Clique em **documentation-preview-pr-${prNumber}** na seção *Artifacts*
+            3. Extraia o arquivo baixado e abra \`index.html\` no navegador
+
+            ---
+
+            *O artifact ficará disponível por 7 dias.*`
+              : `## 📖 Pré-visualização da Documentação
+
+            ✅ A documentação foi compilada com sucesso!
+
+            ### 🔗 Acessar a pré-visualização:
+            **[Visualizar documentação →](${previewUrl})**
+
+            Esta pré-visualização estará disponível enquanto o PR estiver aberto.
+
+            ---
+
+            *Ao fazer merge do PR, a pré-visualização será automaticamente removida.*`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: owner,
+              repo: repo,
+              issue_number: prNumber
+            });
+
+            for (const comment of comments.data) {
+              if (comment.user.type === 'Bot' && comment.body.includes('Pré-visualização da Documentação')) {
+                await github.rest.issues.updateComment({
+                  owner: owner,
+                  repo: repo,
+                  comment_id: comment.id,
+                  body: body
+                });
+                return;
+              }
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: owner,
+              repo: repo,
+              body: body
+            });

--- a/.github/workflows/deploy-preview-documentation.yml
+++ b/.github/workflows/deploy-preview-documentation.yml
@@ -41,6 +41,7 @@ jobs:
         run: mkdocs build
 
       - name: Deploy to GitHub Pages (PR Preview)
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -54,46 +55,31 @@ jobs:
             const { owner, repo } = context.repo;
             const issue = context.issue;
             const prNumber = issue.number;
-            const comment = `## 📖 Pré-visualização da Documentação
-
-            ✅ A documentação foi compilada com sucesso!
-
-            ### 🔗 Acessar a pré-visualização:
-            **[Visualizar documentação →](https://docs.cumbuca.dev/preview/pr/${prNumber}/)**
-
-            Esta pré-visualização estará disponível enquanto o PR estiver aberto.
-
-            ---
-
-            *Ao fazer merge do PR, a pré-visualização será automaticamente removida.*
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: owner,
-              repo: repo,
-              body: comment
-            });
-
-      - name: Find and update existing comment
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const issue = context.issue;
-            const prNumber = issue.number;
+            const isFork =
+              context.payload.pull_request.head.repo.full_name !== `${owner}/${repo}`;
+            const runId = context.runId;
 
             const previewUrl = `https://docs.cumbuca.dev/preview/pr/${prNumber}/`;
 
-            const comments = await github.rest.issues.listComments({
-              owner: owner,
-              repo: repo,
-              issue_number: prNumber
-            });
+            const body = isFork
+              ? `## 📖 Pré-visualização da Documentação
 
-            for (const comment of comments.data) {
-              if (comment.user.type === 'Bot' && comment.body.includes('Pré-visualização da Documentação')) {
-                const newBody = `## 📖 Pré-visualização da Documentação
+            ✅ A documentação foi compilada com sucesso!
+
+            ### 📦 Baixar pré-visualização:
+            Como este PR vem de um fork, o deploy automático não é possível por restrições de segurança do GitHub Actions.
+
+            **[⬇️ Acessar artifact da documentação](https://github.com/${owner}/${repo}/actions/runs/${runId})**
+
+            1. Acesse o link acima
+            2. Clique em **documentation-preview-pr-${prNumber}** na seção *Artifacts*
+            3. Extraia o arquivo baixado e abra \`index.html\` no navegador
+
+            ---
+
+            *O artifact ficará disponível por 7 dias.*`
+              : 
+              `## 📖 Pré-visualização da Documentação
 
             ✅ A documentação foi compilada com sucesso!
 
@@ -104,18 +90,32 @@ jobs:
 
             ---
 
-            *Ao fazer merge do PR, a pré-visualização será automaticamente removida.*
-            `;
+            *Ao fazer merge do PR, a pré-visualização será automaticamente removida.*`;
 
+            const comments = await github.rest.issues.listComments({
+              owner: owner,
+              repo: repo,
+              issue_number: prNumber
+            });
+
+            for (const comment of comments.data) {
+              if (comment.user.type === 'Bot' && comment.body.includes('Pré-visualização da Documentação')) {
                 await github.rest.issues.updateComment({
                   owner: owner,
                   repo: repo,
                   comment_id: comment.id,
-                  body: newBody
+                  body: body
                 });
                 return;
               }
             }
+
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: owner,
+              repo: repo,
+              body: body
+            });
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-preview-documentation.yml
+++ b/.github/workflows/deploy-preview-documentation.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   preview:
@@ -48,74 +47,14 @@ jobs:
           publish_dir: ./site
           destination_dir: preview/pr/${{ github.event.pull_request.number }}
 
-      - name: Comment on PR with preview link
-        uses: actions/github-script@v8
+      - name: Save PR metadata
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload PR metadata artifact
+        uses: actions/upload-artifact@v7
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const issue = context.issue;
-            const prNumber = issue.number;
-            const isFork =
-              context.payload.pull_request.head.repo.full_name !== `${owner}/${repo}`;
-            const runId = context.runId;
-
-            const previewUrl = `https://docs.cumbuca.dev/preview/pr/${prNumber}/`;
-
-            const body = isFork
-              ? `## 📖 Pré-visualização da Documentação
-
-            ✅ A documentação foi compilada com sucesso!
-
-            ### 📦 Baixar pré-visualização:
-            Como este PR vem de um fork, o deploy automático não é possível por restrições de segurança do GitHub Actions.
-
-            **[⬇️ Acessar artifact da documentação](https://github.com/${owner}/${repo}/actions/runs/${runId})**
-
-            1. Acesse o link acima
-            2. Clique em **documentation-preview-pr-${prNumber}** na seção *Artifacts*
-            3. Extraia o arquivo baixado e abra \`index.html\` no navegador
-
-            ---
-
-            *O artifact ficará disponível por 7 dias.*`
-              : 
-              `## 📖 Pré-visualização da Documentação
-
-            ✅ A documentação foi compilada com sucesso!
-
-            ### 🔗 Acessar a pré-visualização:
-            **[Visualizar documentação →](${previewUrl})**
-
-            Esta pré-visualização estará disponível enquanto o PR estiver aberto.
-
-            ---
-
-            *Ao fazer merge do PR, a pré-visualização será automaticamente removida.*`;
-
-            const comments = await github.rest.issues.listComments({
-              owner: owner,
-              repo: repo,
-              issue_number: prNumber
-            });
-
-            for (const comment of comments.data) {
-              if (comment.user.type === 'Bot' && comment.body.includes('Pré-visualização da Documentação')) {
-                await github.rest.issues.updateComment({
-                  owner: owner,
-                  repo: repo,
-                  comment_id: comment.id,
-                  body: body
-                });
-                return;
-              }
-            }
-
-            await github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: owner,
-              repo: repo,
-              body: body
-            });
+          name: pr-metadata
+          path: pr_number.txt
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## O que foi alterado

O workflow de preview da documentação foi dividido em dois:

* `deploy-preview-documentation.yml`: faz o build, salva o número do PR como artifact e continua publicando o preview apenas para PRs internos.
* `comment-preview-documentation.yml`: novo workflow responsável por comentar no PR após o build, usando `workflow_run`.

O comentário agora é adaptado à origem do PR:

* PR interno: mostra o link do preview
* PR de fork: mostra como baixar o artifact

Além disso, a lógica de comentário continua atualizando o comentário existente em vez de criar vários.

## Motivo da mudança

PRs de forks recebem um `GITHUB_TOKEN` com permissões limitadas. Isso fazia o deploy para `gh-pages` falhar e também impedia o comentário no PR com erro 403.

Separar o fluxo em dois workflows segue o padrão recomendado para esse cenário: o `pull_request` faz apenas o processamento seguro do PR, e o `workflow_run` faz a etapa que precisa de escrita no PR.

## Issue relacionada

Resolve #93

## Referência

* [Keeping your GitHub Actions and workflows secure — Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) — GitHub Security Lab
